### PR TITLE
Fix cutting down trees with items not in the tools list

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,4 @@
+v6.0.54 - Fixed a bug where items not explicitly in the tools list could be used to cut down a tree
 v6.0.53 - Please let's use the jenkins again
 v6.0.10 - Update bukkit version to 1.14 (still compatible with 1.13)
 v6.0.9 - Update integration with CoreProtect to use new API call

--- a/src/me/itsatacoshop247/TreeAssist/core/Utils.java
+++ b/src/me/itsatacoshop247/TreeAssist/core/Utils.java
@@ -509,7 +509,7 @@ public final class Utils {
 				continue; // skip item IDs
 			}
 			String tool = (String) obj;
-			if (!tool.startsWith(inHand.getType().name())) {
+			if (!tool.equalsIgnoreCase(inHand.getType().name())) {
 				continue; // skip other names
 			}
 	


### PR DESCRIPTION
Closes #23
This bug is caused by items such as "Stone" and "Diamond" matching the beginning of certain tools such as "Stone Axe" and "Diamond Axe". A simple one line change takes care of that.