### PR TITLE
Configurable lookup time for CoreProtect blocklist

### DIFF
--- a/src/me/itsatacoshop247/TreeAssist/TreeAssist.java
+++ b/src/me/itsatacoshop247/TreeAssist/TreeAssist.java
@@ -393,6 +393,8 @@ public class TreeAssist extends JavaPlugin {
         items.put("Block Statistics.Pickup", "false");
         items.put("Block Statistics.Mine Block", "false");
 
+        items.put("Placed Blocks.Handler Lookup Time", "86400");
+
         return items;
     }
 

--- a/src/me/itsatacoshop247/TreeAssist/blocklists/CoreProtectBlockList.java
+++ b/src/me/itsatacoshop247/TreeAssist/blocklists/CoreProtectBlockList.java
@@ -13,10 +13,11 @@ import java.util.List;
 
 public class CoreProtectBlockList implements BlockList {
 	private final CoreProtectAPI protect;
-	private static final int LOOKUP_TIME = 60*60*24;
+	private final int LOOKUP_TIME;
 	
 	public CoreProtectBlockList() {
 		protect = getCoreProtect();
+		LOOKUP_TIME = Utils.plugin.getConfig().getInt("Placed Blocks.Handler Lookup Time", 60*60*24);
 	}
 	private CoreProtectAPI getCoreProtect() {
 		Plugin plugin = Bukkit.getPluginManager().getPlugin("CoreProtect");
@@ -43,7 +44,7 @@ public class CoreProtectBlockList implements BlockList {
 
 	@Override
 	public boolean isPlayerPlaced(Block block) {
-		if (protect == null) {
+		if (protect == null || LOOKUP_TIME <= 0) {
 			return false;
 		}
 		List<String[]> lookup = protect.blockLookup(block, LOOKUP_TIME);

--- a/src/me/itsatacoshop247/TreeAssist/blocklists/CoreProtectBlockList.java
+++ b/src/me/itsatacoshop247/TreeAssist/blocklists/CoreProtectBlockList.java
@@ -13,11 +13,11 @@ import java.util.List;
 
 public class CoreProtectBlockList implements BlockList {
 	private final CoreProtectAPI protect;
-	private final int LOOKUP_TIME;
+	private int lookupTime;
 	
 	public CoreProtectBlockList() {
 		protect = getCoreProtect();
-		LOOKUP_TIME = Utils.plugin.getConfig().getInt("Placed Blocks.Handler Lookup Time", 60*60*24);
+		lookupTime = Utils.plugin.getConfig().getInt("Placed Blocks.Handler Lookup Time", 60*60*24);
 	}
 	private CoreProtectAPI getCoreProtect() {
 		Plugin plugin = Bukkit.getPluginManager().getPlugin("CoreProtect");
@@ -44,10 +44,10 @@ public class CoreProtectBlockList implements BlockList {
 
 	@Override
 	public boolean isPlayerPlaced(Block block) {
-		if (protect == null || LOOKUP_TIME <= 0) {
+		if (protect == null || lookupTime <= 0) {
 			return false;
 		}
-		List<String[]> lookup = protect.blockLookup(block, LOOKUP_TIME);
+		List<String[]> lookup = protect.blockLookup(block, lookupTime);
 
 		for (String[] value : lookup) {
 			ParseResult result = protect.parseResult(value);


### PR DESCRIPTION
Was currently hard coded to a day, but this adds some nice flexibility. The lookup time is used for CoreProtect's block lookup, to determine whether it has been "lately placed". It's desirable to change this because someone may want trees to be able to be chopped using TreeAssist immediately, after a minute, an hour, a day, etc.