### PR TITLE
Correcting the Minimum Height of mushroom_stem

### DIFF
--- a/src/main/resources/trees/mushroom.yml
+++ b/src/main/resources/trees/mushroom.yml
@@ -28,7 +28,7 @@ Parent: default
 Trunk:
 
   # How high does it need to be to qualify as a tree
-  Minimum Height: 5
+  Minimum Height: 4
 
   # One of these materials needs to be part of the trunk for it to count as a trunk
   Materials:


### PR DESCRIPTION
![Zulu-21 Screenshot 2024 12 23 - 13 09 57 11](https://github.com/user-attachments/assets/86680552-e190-45b6-ae43-1d38beffc2e9)
The minimum height of red_mushroom's mushroom_stem is 4.