### PR TITLE
Add Folia support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.4</version>
+				<version>3.5.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -172,6 +172,7 @@
 							<artifactSet>
 								<includes>
 									<include>net.slipcor:core</include>
+									<include>com.tcoded:FoliaLib</include>
 								</includes>
 							</artifactSet>
 							<filters>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
 			<id>placeholderapi-repo</id>
 			<url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
 		</repository>
+		<repository>
+			<id>tcoded-releases</id>
+			<url>https://repo.tcoded.com/releases</url>
+		</repository>
 	</repositories>
 	<dependencies>
 		<dependency>
@@ -27,6 +31,12 @@
 			<artifactId>spigot-api</artifactId>
 			<version>1.17-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.tcoded</groupId>
+			<artifactId>FoliaLib</artifactId>
+			<version>0.5.1</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q.worldguard</groupId>
@@ -179,6 +189,10 @@
 									<includes>
 										<include>net.slipcor.core.*</include>
 									</includes>
+								</relocation>
+								<relocation>
+									<pattern>com.tcoded.folialib</pattern>
+									<shadedPattern>net.slipcor.TreeAssist.lib.folialib</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/src/main/java/net/slipcor/treeassist/TreeAssist.java
+++ b/src/main/java/net/slipcor/treeassist/TreeAssist.java
@@ -494,7 +494,7 @@ public class TreeAssist extends CorePlugin {
                     String.valueOf(coolDown)));
         }
         CoolDownCounter cc = new CoolDownCounter(player, coolDown);
-        cc.runTaskTimer(this, 20L, 20L);
+        TreeAssist.getScheduler().runTimer(cc, 20L, 20L);
         coolDowns.put(player.getName(), cc);
     }
 

--- a/src/main/java/net/slipcor/treeassist/TreeAssist.java
+++ b/src/main/java/net/slipcor/treeassist/TreeAssist.java
@@ -316,7 +316,7 @@ public class TreeAssist extends CorePlugin {
     }
 
     public void onDisable() {
-        this.getServer().getScheduler().cancelTasks(this);
+        TreeAssist.getScheduler().cancelAllTasks();
         if (this.blockList instanceof FlatFileBlockList) {
             blockList.save(true);
         }

--- a/src/main/java/net/slipcor/treeassist/TreeAssist.java
+++ b/src/main/java/net/slipcor/treeassist/TreeAssist.java
@@ -1,5 +1,7 @@
 package net.slipcor.treeassist;
 
+import com.tcoded.folialib.FoliaLib;
+import com.tcoded.folialib.impl.PlatformScheduler;
 import net.slipcor.core.*;
 import net.slipcor.treeassist.blocklists.*;
 import net.slipcor.treeassist.commands.*;
@@ -59,6 +61,8 @@ public class TreeAssist extends CorePlugin {
     public boolean auraskills = false; // Whether AuraSkills has been found and hooked into
     public boolean makeEvents = false;
 
+    private static PlatformScheduler scheduler;
+
     private File configFile;
     private MainConfig config;
 
@@ -99,6 +103,14 @@ public class TreeAssist extends CorePlugin {
         defaultTreeDefinitions.add("trees/mushroom.yml");
         defaultTreeDefinitions.add("trees/mushroom/mushroom-brown.yml");
         defaultTreeDefinitions.add("trees/mushroom/mushroom-red.yml");
+    }
+
+    /**
+     * Get the scheduler for the current platform
+     * @return agnostic scheduler
+     */
+    public static PlatformScheduler getScheduler() {
+        return TreeAssist.scheduler;
     }
 
     /**
@@ -315,6 +327,10 @@ public class TreeAssist extends CorePlugin {
         checkAureliumSkills();
         checkMcMMO();
         checkJobs();
+        if (TreeAssist.scheduler == null) {
+            TreeAssist.scheduler = new FoliaLib(this).getScheduler();
+        }
+
         this.makeEvents = config().getBoolean(MainConfig.CFG.PLUGINS_USE_CUSTOM_EVENTS);
 
         if (worldGuard != null) {

--- a/src/main/java/net/slipcor/treeassist/blocklists/FlatFileBlockList.java
+++ b/src/main/java/net/slipcor/treeassist/blocklists/FlatFileBlockList.java
@@ -215,7 +215,9 @@ public class FlatFileBlockList extends EmptyBlockList {
             e.printStackTrace();
         }
 
-        Bukkit.getScheduler().runTaskTimer(TreeAssist.instance, () -> FlatFileBlockList.this.save(false), 1200, 1200);
+        TreeAssist.getScheduler().runTimer((t)->{
+            FlatFileBlockList.this.save(false);
+        }, 1200, 1200);
     }
 
     @Override
@@ -453,7 +455,7 @@ public class FlatFileBlockList extends EmptyBlockList {
         if (force) {
             new RunLater().run();
         } else {
-            Bukkit.getScheduler().runTaskAsynchronously(TreeAssist.instance, new RunLater());
+            TreeAssist.getScheduler().runAsync((t) -> new RunLater());
         }
     }
 }

--- a/src/main/java/net/slipcor/treeassist/commands/CommandForceBreak.java
+++ b/src/main/java/net/slipcor/treeassist/commands/CommandForceBreak.java
@@ -65,7 +65,9 @@ public class CommandForceBreak extends CoreCommand {
                 }
             }
 
-            Bukkit.getScheduler().runTaskLater(TreeAssist.instance, () -> TreeAssist.instance.setCoolDownOverride(player.getName(), false), 200);
+            TreeAssist.getScheduler().runLater((t) -> {
+                TreeAssist.instance.setCoolDownOverride(player.getName(), false);
+            }, 200);
 
             return;
         }

--- a/src/main/java/net/slipcor/treeassist/discovery/DiscoveryResult.java
+++ b/src/main/java/net/slipcor/treeassist/discovery/DiscoveryResult.java
@@ -1,5 +1,6 @@
 package net.slipcor.treeassist.discovery;
 
+import com.tcoded.folialib.FoliaLib;
 import net.slipcor.treeassist.TreeAssist;
 import net.slipcor.treeassist.core.TreeAssistDebugger;
 import net.slipcor.treeassist.utils.BlockUtils;
@@ -7,6 +8,7 @@ import net.slipcor.treeassist.utils.CommandUtils;
 import net.slipcor.treeassist.yml.MainConfig;
 import net.slipcor.treeassist.yml.TreeConfig;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -144,24 +146,28 @@ public class DiscoveryResult {
                 }
             }
         }
-        Bukkit.getScheduler().runTaskLater(TreeAssist.instance, new Runnable() {
-            @Override
-            public void run() {
-                TreeAssist.instance.sendPrefixed(player, "Removing valid tree #" + System.identityHashCode(tree));
 
-                for (Block block : tree.trunk) {
-                    player.sendBlockChange(block.getLocation(), block.getType().createBlockData());
-                }
+        Location location;
+        if (tree.getBlocks().isEmpty()) {
+            location = player.getLocation();
+        } else {
+            location = tree.getBlocks().getFirst().getLocation();
+        }
+        TreeAssist.getScheduler().runAtLocationLater(location, (t) -> {
+            TreeAssist.instance.sendPrefixed(player, "Removing valid tree #" + System.identityHashCode(tree));
 
-                for (Block block : tree.extras) {
-                    player.sendBlockChange(block.getLocation(), block.getType().createBlockData());
-                }
+            for (Block block : tree.trunk) {
+                player.sendBlockChange(block.getLocation(), block.getType().createBlockData());
+            }
 
-                if (tree.branchMap != null) {
-                    for (List<Block> list : tree.branchMap.values()) {
-                        for (Block block : list) {
-                            player.sendBlockChange(block.getLocation(), block.getType().createBlockData());
-                        }
+            for (Block block : tree.extras) {
+                player.sendBlockChange(block.getLocation(), block.getType().createBlockData());
+            }
+
+            if (tree.branchMap != null) {
+                for (List<Block> list : tree.branchMap.values()) {
+                    for (Block block : list) {
+                        player.sendBlockChange(block.getLocation(), block.getType().createBlockData());
                     }
                 }
             }

--- a/src/main/java/net/slipcor/treeassist/discovery/TreeStructure.java
+++ b/src/main/java/net/slipcor/treeassist/discovery/TreeStructure.java
@@ -25,7 +25,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 
 import java.io.File;
 import java.util.*;
@@ -2216,9 +2216,7 @@ public class TreeStructure {
         final boolean cleanUpLeaves = config.getBoolean(TreeConfig.CFG.AUTOMATIC_DESTRUCTION_CLEANUP_LEAVES);
         final List<Material> leaves = config.getMaterials(TreeConfig.CFG.BLOCKS_MATERIALS);
 
-        class InstantRunner extends BukkitRunnable {
-            @Override
-            public void run() {
+        java.util.function.Consumer<WrappedTask> instantRunner = (task) -> {
                 if (offset < 0) {
                     for (Block block : removeBlocks) {
                         if (sapling.equals(block.getType())) {
@@ -2228,7 +2226,7 @@ public class TreeStructure {
                         debug.i("InstantRunner: 1 " + BlockUtils.printBlock(block));
                         maybeBreakBlock(block, tool, player, statPickup, statMineBlock, damage, creative);
                         if (damage && ToolUtils.willBreak(tool, player)) {
-                            this.cancel();
+                            task.cancel();
                             TreeAssistPlayerListener.removeDestroyer(player, TreeStructure.this);
                             // we skip clearing the block list because there was an issue that requires cleanup
                             return;
@@ -2248,7 +2246,7 @@ public class TreeStructure {
                             debug.i("InstantRunner: 2b " + BlockUtils.printBlock(block));
                             maybeBreakBlock(block, tool, player, statPickup, statMineBlock, damage, creative);
                             if (damage && ToolUtils.willBreak(tool, player)) {
-                                this.cancel();
+                                task.cancel();
                                 TreeAssistPlayerListener.removeDestroyer(player, TreeStructure.this);
                                 // we skip clearing the block list because there was an issue that requires cleanup
                                 return;
@@ -2260,22 +2258,20 @@ public class TreeStructure {
                 }
                 try {
                     TreeAssistPlayerListener.removeDestroyer(player, TreeStructure.this);
-                    this.cancel();
+                    task.cancel();
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-            }
-
-        }
+        };
 
         CleanRunner cleaner = (new CleanRunner(this, offset, removeBlocks, sapling, cleanUpLeaves, leaves));
         if (player != null) {
-            (new InstantRunner()).runTaskTimer(TreeAssist.instance, delay, offset);
+            TreeAssist.getScheduler().runAtLocationTimer(bottom.getLocation(), instantRunner, delay, offset);
         }
 
         int cleanDelay = config.getInt(TreeConfig.CFG.AUTOMATIC_DESTRUCTION_CLEANUP_DELAY_TIME);
 
-        cleaner.runTaskTimer(TreeAssist.instance, cleanDelay *20L, offset);
+        TreeAssist.getScheduler().runAtLocationTimer(bottom.getLocation(), cleaner, cleanDelay *20L, offset);
     }
 
     /**

--- a/src/main/java/net/slipcor/treeassist/listeners/TreeAssistBlockListener.java
+++ b/src/main/java/net/slipcor/treeassist/listeners/TreeAssistBlockListener.java
@@ -154,7 +154,7 @@ public class TreeAssistBlockListener implements Listener {
                     return;
                 }
                 Runnable b = new TreeAssistReplant(block, event.getType(), config);
-                plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, b, 20);
+                TreeAssist.getScheduler().runAtLocationLater(block.getLocation(), (t) -> b.run(), 20);
                 debug.explain(TreeAssistDebugger.ErrorType.SAPLING, block, ChatColor.GREEN + "Burning block sapling replacement should have worked!");
                 return;
             }

--- a/src/main/java/net/slipcor/treeassist/listeners/TreeAssistPlayerListener.java
+++ b/src/main/java/net/slipcor/treeassist/listeners/TreeAssistPlayerListener.java
@@ -245,7 +245,12 @@ public class TreeAssistPlayerListener implements Listener {
             plugin.toggleGlobal(event.getPlayer().getName());
         }
         if (event.getPlayer().isOp() && plugin.getUpdater() != null) {
-            plugin.getUpdater().message(event.getPlayer());
+            try {
+                plugin.getUpdater().message(event.getPlayer());
+            } catch (UnsupportedOperationException ignored) {
+                // Folia does not support Bukkit's scheduler - update check skipped
+                // This is a pending chore for slipcor's core lib (replace Bukkit scheduler)
+            }
         }
     }
 

--- a/src/main/java/net/slipcor/treeassist/runnables/CleanRunner.java
+++ b/src/main/java/net/slipcor/treeassist/runnables/CleanRunner.java
@@ -1,5 +1,6 @@
 package net.slipcor.treeassist.runnables;
 
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 import net.slipcor.treeassist.TreeAssist;
 import net.slipcor.treeassist.core.TreeAssistDebugger;
 import net.slipcor.treeassist.discovery.FailReason;
@@ -10,12 +11,12 @@ import net.slipcor.treeassist.yml.MainConfig;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
-public class CleanRunner extends BukkitRunnable {
+public class CleanRunner implements Consumer<WrappedTask> {
     private final TreeStructure me;
     private final int offset;
     private final Set<Block> removeBlocks;
@@ -34,7 +35,7 @@ public class CleanRunner extends BukkitRunnable {
     }
 
     @Override
-    public void run() {
+    public void accept(WrappedTask task) {
         boolean generateDrops = (me instanceof LeavesStructure) && TreeAssist.instance.config().getBoolean(MainConfig.CFG.DESTRUCTION_FAST_LEAF_DECAY_REGULAR_DROPS);
         debug.i("CleanRunner: will generate drops: " + generateDrops);
         ItemStack breakTool = generateDrops ? new ItemStack(Material.AIR, 1) : null;
@@ -84,7 +85,7 @@ public class CleanRunner extends BukkitRunnable {
         me.setFailReason(FailReason.INVALID_BLOCK);
         try {
             TreeAssist.instance.treeRemove(me);
-            this.cancel();
+            task.cancel();
         } catch (Exception e) {
         }
     }

--- a/src/main/java/net/slipcor/treeassist/runnables/CoolDownCounter.java
+++ b/src/main/java/net/slipcor/treeassist/runnables/CoolDownCounter.java
@@ -1,14 +1,17 @@
 package net.slipcor.treeassist.runnables;
 
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 import net.slipcor.treeassist.TreeAssist;
 import net.slipcor.treeassist.yml.Language;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 
-public class CoolDownCounter extends BukkitRunnable {
+import java.util.function.Consumer;
+
+public class CoolDownCounter implements Consumer<WrappedTask> {
     private final String name;
     private int seconds;
+    private WrappedTask wrappedTask;
 
     /**
      * A runnable counting down by the second until a player can use the auto destruction again
@@ -22,13 +25,20 @@ public class CoolDownCounter extends BukkitRunnable {
     }
 
     @Override
-    public void run() {
+    public void accept(WrappedTask task) {
+        this.wrappedTask = task;
         if (--seconds <= 0) {
             commit();
             try {
-                this.cancel();
+                task.cancel();
             } catch (IllegalStateException e) {
             }
+        }
+    }
+
+    public void cancel() {
+        if (wrappedTask != null) {
+            wrappedTask.cancel();
         }
     }
 

--- a/src/main/java/net/slipcor/treeassist/runnables/TreeAssistAntiGrow.java
+++ b/src/main/java/net/slipcor/treeassist/runnables/TreeAssistAntiGrow.java
@@ -1,12 +1,13 @@
 package net.slipcor.treeassist.runnables;
 
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 import net.slipcor.treeassist.TreeAssist;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 
 /**
@@ -16,10 +17,10 @@ public class TreeAssistAntiGrow {
     final Map<String, Integer> blocks = new HashMap<>();
     private boolean lock = false;
 
-    class AntiGrowRunner extends BukkitRunnable {
+    class AntiGrowRunner implements Consumer<WrappedTask> {
 
         @Override
-        public void run() {
+        public void accept(WrappedTask task) {
 
             final Map<String, Integer> temp = new HashMap<>();
 
@@ -44,7 +45,7 @@ public class TreeAssistAntiGrow {
             }
 
             if (blocks.size() < 1) {
-                this.cancel();
+                task.cancel();
             }
         }
     }
@@ -63,7 +64,7 @@ public class TreeAssistAntiGrow {
         if (blocks.size() < 1) {
             // empty, refill!
             blocks.put(locToString(block.getLocation()), seconds);
-            new AntiGrowRunner().runTaskTimer(TreeAssist.instance, 20L, 20L);
+            TreeAssist.getScheduler().runTimer(new AntiGrowRunner(), 20L, 20L);
         } else {
             // add
             while (lock) {

--- a/src/main/java/net/slipcor/treeassist/runnables/TreeAssistReplantDelay.java
+++ b/src/main/java/net/slipcor/treeassist/runnables/TreeAssistReplantDelay.java
@@ -49,8 +49,7 @@ public class TreeAssistReplantDelay {
         }
         TreeStructure.debug.i("committing TreeAssistReplantDelay " + this.tree);
 
-        TreeAssist.instance.getServer().getScheduler()
-                .scheduleSyncDelayedTask(TreeAssist.instance, runnable, 20 * delayTicks);
+        TreeAssist.getScheduler().runAtLocationLater(saplingBlock.getLocation(), (t) -> runnable.run(), 20L * delayTicks);
         int timeToProtect = tree.getConfig().getInt(TreeConfig.CFG.REPLANTING_PROTECT_FOR_SECONDS);
 
         timeToProtect += delayTicks; // prevent the protection running out before the sapling was even planted
@@ -61,30 +60,18 @@ public class TreeAssistReplantDelay {
             if (delayTicks > 0) {
                 TreeStructure.debug.i("Sapling will be protected (after " + delayTicks + ") at " + BlockUtils.printBlock(saplingBlock));
                 Runnable X = new TreeAssistProtect(saplingBlock.getLocation());
-                TreeAssist.instance
-                        .getServer()
-                        .getScheduler()
-                        .scheduleSyncDelayedTask(
-                                TreeAssist.instance,
-                                () -> TreeAssist.instance.saplingLocationList.add(saplingBlock.getLocation()),
-                                20 * delayTicks);
-                TreeAssist.instance
-                        .getServer()
-                        .getScheduler()
-                        .scheduleSyncDelayedTask(
-                                TreeAssist.instance,
-                                X, 20 * timeToProtect);
+                TreeAssist.getScheduler().runAtLocationLater(saplingBlock.getLocation(),
+                        (t) -> TreeAssist.instance.saplingLocationList.add(saplingBlock.getLocation()),
+                        20L * delayTicks);
+                TreeAssist.getScheduler().runAtLocationLater(saplingBlock.getLocation(),
+                        (t) -> X.run(), 20L * timeToProtect);
 
             } else {
                 TreeStructure.debug.i("Sapling will be protected at " + BlockUtils.printBlock(saplingBlock));
                 TreeAssist.instance.saplingLocationList.add(saplingBlock.getLocation());
                 Runnable X = new TreeAssistProtect(saplingBlock.getLocation());
-                TreeAssist.instance
-                        .getServer()
-                        .getScheduler()
-                        .scheduleSyncDelayedTask(
-                                TreeAssist.instance,
-                                X, 20 * timeToProtect);
+                TreeAssist.getScheduler().runAtLocationLater(saplingBlock.getLocation(),
+                        (t) -> X.run(), 20L * timeToProtect);
             }
         } else  {
             TreeStructure.debug.i("Saplings do not need to be protected");

--- a/src/main/java/net/slipcor/treeassist/runnables/TreeAssistSaplingSelfPlant.java
+++ b/src/main/java/net/slipcor/treeassist/runnables/TreeAssistSaplingSelfPlant.java
@@ -50,8 +50,8 @@ public class TreeAssistSaplingSelfPlant implements Runnable {
 				return;
 			}
 		}
-		
-		Bukkit.getScheduler().runTaskLater(TreeAssist.instance, this, delay);
+
+		TreeAssist.getScheduler().runLater(this, delay);
 	}
 
 	private Block findBlock(Item item) {
@@ -87,7 +87,7 @@ public class TreeAssistSaplingSelfPlant implements Runnable {
 			block.setType(overrideMaterial == null ? config.getMaterial(TreeConfig.CFG.REPLANTING_MATERIAL) : overrideMaterial);
 			if (drop.getItemStack().getAmount() > 1) {
 				drop.getItemStack().setAmount(drop.getItemStack().getAmount()-1);
-				Bukkit.getScheduler().runTaskLater(TreeAssist.instance, this, delay);
+				TreeAssist.getScheduler().runLater(this, delay);
 				return;
 			}
 			drop.remove();

--- a/src/main/java/net/slipcor/treeassist/utils/BlockUtils.java
+++ b/src/main/java/net/slipcor/treeassist/utils/BlockUtils.java
@@ -264,7 +264,7 @@ public class BlockUtils {
                 TreeAssist.instance.treeAdd(leaves);
 
                 CleanRunner cleaner = (new CleanRunner(leaves, delay, new LinkedHashSet<>(breakables), Material.AIR, true, new ArrayList<>()));
-                cleaner.runTaskTimer(TreeAssist.instance, delay, delay);
+                TreeAssist.getScheduler().runAtLocationTimer(block.getLocation(), cleaner, delay, delay);
             }
         }
     }

--- a/src/main/java/net/slipcor/treeassist/utils/BlockUtils.java
+++ b/src/main/java/net/slipcor/treeassist/utils/BlockUtils.java
@@ -86,7 +86,7 @@ public class BlockUtils {
                 falling.setVelocity(
                         new Vector(looking.getX(), -level, looking.getZ())
                 );
-                Bukkit.getScheduler().runTaskLater(TreeAssist.instance, () -> falling.setGravity(true), 30L);
+                TreeAssist.getScheduler().runAtEntityLater(falling, (t) -> falling.setGravity(true), 30L);
             }
 
             fallingBlocks.add(falling);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ authors: [slipcor, FriendlyBaron]
 description: TreeAssist
 softdepend: [AureliumSkills, AuraSkills, CoreProtect, Jobs, mcMMO, Prism, LogBlock, PlaceholderAPI, WorldGuard]
 dev-url: https://www.spigotmc.org/resources/treeassist.67436/
+folia-supported: true
 commands:
   TreeAssist:
     description: Turn TreeAssist features on or off


### PR DESCRIPTION
Adds Folia support. All that was needed was replacing the scheduler by an agnostic scheduler that will work on spigot/paper and Folia. I used [tcoded's FoliaLib](https://github.com/TechnicallyCoded/FoliaLib), which I've used on a dozen plugins so far and it's the one I've found to be most straightforward.

Tested it on folia 1.21.11. Do note the autoupdater checks on PlayerJoinEvent is not working, because the core lib uses a Bukkit scheduler to run an asynchronous fetch task to get version update details.

So far I've only tested breaking a tree. It works as expected, replanting the sapling etc. I did not test any other features.